### PR TITLE
Create Mobile Header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,40 +30,10 @@
   margin: 5rem 0 0 5rem;
 }
 
-@media (max-width: 1200px) {
-  .add-stonks {
-    margin: 2rem 0 0 4.5rem;
-    display: grid;
-    grid-template-columns: 100%;
-    border: hsl(0, 0%, 80%) solid 1px;
-    border-radius: 10px;
-    width: 80%;
-  }
-}
-
-@media (min-width: 1200px) {
-  .add-stonks {
-    margin: 5rem 0 0 4.5rem;
-    display: grid;
-    grid-template-columns: 45% 30%;
-    border: hsl(0, 0%, 80%) solid 1px;
-    border-radius: 10px;
-    width: 80%;
-  }
-}
-
-.add-stonk-form {
-  padding: 20px;
-}
-
-.add-stonk-heading {
-  color: #282c34;
-  font-size: 23px;
-}
-
 .input-label {
   display: block;
-  margin-bottom: 1rem;
+  margin: 1rem 0;
+  letter-spacing: 0.5px;
 }
 
 .textbox {
@@ -124,7 +94,11 @@ input:-webkit-autofill:active {
 .form-button {
   width: 140px;
   height: 45px;
-  background-color: #85bf31;
+  /* background-color: #85bf31; */
+  background-image: linear-gradient(
+    var(--main-primary-color),
+    var(--main-secondary-color)
+  );
   color: white;
   font-size: 16px;
   font-weight: 600;
@@ -134,6 +108,7 @@ input:-webkit-autofill:active {
 }
 
 .form-button:hover {
+  background-image: none;
   background-color: rgb(106, 155, 37);
 }
 

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -37,7 +37,7 @@
 }
 
 .app-header .explanation-text {
-  font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
+  /* font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif; */
   font-weight: 200;
   font-size: 16px;
   color: #ffffff;
@@ -74,8 +74,20 @@
   margin-top: 0.15rem;
 }
 
-/* Mobile Header */
+/* Mobile Nav and Header */
 .mobile-header {
+  display: flex;
+  width: 100vw;
+  background-color: var(--main-secondary-color);
+  padding: 0.7rem 0;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+
+  letter-spacing: 0.25px;
+}
+
+.mobile-navbar {
   display: flex;
   z-index: 1000;
   background-color: var(--main-secondary-color);

--- a/src/components/Header/MobileHeader.js
+++ b/src/components/Header/MobileHeader.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default ({ pageName = "STONKS" }) => (
+  <div className="mobile-header">{pageName}</div>
+);

--- a/src/components/Header/MobileNavbar.js
+++ b/src/components/Header/MobileNavbar.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 
 export default function MobileNavbar(props) {
   return (
-    <div className="mobile-header">
+    <div className="mobile-navbar">
       <Link to="/">
         <span className="mobile-icon">
           <Home size={22} />

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,13 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
   background-color: #1a1b26;
 }
 
-code {
+/* code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
-}
+} */

--- a/src/pages/AddStonk.js
+++ b/src/pages/AddStonk.js
@@ -4,6 +4,8 @@ import { get, post } from "../data/fetchWrapper";
 import AddStonkForm from "../components/AddStonkForm.js";
 import Metrics from "../components/Metrics";
 import UserContext from "../data/context/UserContext";
+import MobileHeader from "../components/Header/MobileHeader";
+import "./addstonk.css";
 
 export default function AddStonk() {
   const [apiUrl] = useState(getDevOrProdAPIURL());
@@ -109,19 +111,22 @@ export default function AddStonk() {
   }
 
   return (
-    <article className="add-stonks">
-      <AddStonkForm
-        getStonkCalculation={getStonkCalculation}
-        setTickerAndGetQuote={setTickerAndGetQuote}
-        setInputValue={setInputValue}
-        previousGrowthRate={previousGrowthRate}
-        futureGrowthRate={futureGrowthRate}
-      />
-      <Metrics
-        stonk={stonk}
-        stonkQuote={stonkQuote}
-        addStonkToStonks={addStonk}
-      />
-    </article>
+    <>
+      {context.state.isMobile && <MobileHeader pageName="ADD STONK" />}
+      <article className="add-stonks">
+        <AddStonkForm
+          getStonkCalculation={getStonkCalculation}
+          setTickerAndGetQuote={setTickerAndGetQuote}
+          setInputValue={setInputValue}
+          previousGrowthRate={previousGrowthRate}
+          futureGrowthRate={futureGrowthRate}
+        />
+        <Metrics
+          stonk={stonk}
+          stonkQuote={stonkQuote}
+          addStonkToStonks={addStonk}
+        />
+      </article>
+    </>
   );
 }

--- a/src/pages/AddStonk.js
+++ b/src/pages/AddStonk.js
@@ -16,6 +16,7 @@ export default function AddStonk() {
   const [previousGrowthRate, setPreviousGrowthRate] = useState(0);
 
   const context = useContext(UserContext);
+  const { isMobile } = context.state;
 
   useEffect(() => {
     if (stonkTicker.value) getStonkQuote(stonkTicker.value);
@@ -112,7 +113,7 @@ export default function AddStonk() {
 
   return (
     <>
-      {context.state.isMobile && <MobileHeader pageName="ADD STONK" />}
+      {isMobile && <MobileHeader pageName="ADD STONK" />}
       <article className="add-stonks">
         <AddStonkForm
           getStonkCalculation={getStonkCalculation}

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -5,6 +5,7 @@ import UserContext from "../data/context/UserContext";
 import StonkCards from "../components/StonkCards";
 import SortCardsDropdown from "../components/SortCardsDropdown";
 import "./dashboard.css";
+import MobileHeader from "../components/Header/MobileHeader";
 
 export default function StonksDashboard() {
   const context = useContext(UserContext);
@@ -17,6 +18,7 @@ export default function StonksDashboard() {
 
   return isMobile ? (
     <main className="stonks-container" data-testid="stonks-container">
+      <MobileHeader pageName="DASHBOARD" />
       <MarketBanner />
       <SortCardsDropdown dispatch={sortStonks} />
       {isLoading === true ? (

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -3,8 +3,8 @@ import MobileHeader from "../components/Header/MobileHeader";
 import UserContext from "../data/context/UserContext";
 
 export default function Home(props) {
-  const context = useContext(UserContext);
-  return context.state.isMobile ? (
+  const { isMobile } = useContext(UserContext).state;
+  return isMobile ? (
     <>
       <MobileHeader />
       <main className="home">WELCOME TO THE STONKS APP!</main>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,5 +1,15 @@
-import React from "react";
+import React, { useContext } from "react";
+import MobileHeader from "../components/Header/MobileHeader";
+import UserContext from "../data/context/UserContext";
 
 export default function Home(props) {
-  return <main className="home">WELCOME TO THE STONKS APP!</main>;
+  const context = useContext(UserContext);
+  return context.state.isMobile ? (
+    <>
+      <MobileHeader />
+      <main className="home">WELCOME TO THE STONKS APP!</main>
+    </>
+  ) : (
+    <main className="home">WELCOME TO THE STONKS APP!</main>
+  );
 }

--- a/src/pages/IRR.js
+++ b/src/pages/IRR.js
@@ -6,9 +6,10 @@ import UserContext from "../data/context/UserContext";
 import "./irr.css";
 import "../components/typeahead.css";
 import IRRWidget from "../components/CalculateIRR";
+import MobileHeader from "../components/Header/MobileHeader";
 
 export default function IRR(props) {
-  const { stonks } = useContext(UserContext).state;
+  const { stonks, isMobile } = useContext(UserContext).state;
 
   const [chosenStonk, setChosenStonk] = useState({});
   const [priceChartData, setPriceChartData] = useState([]);
@@ -19,27 +20,34 @@ export default function IRR(props) {
   };
 
   return (
-    <main className="irr-container">
-      <section className="irrform">
-        <LocalTypeahead
-          stonks={stonks}
-          setTickerAndPassStonk={setTickerAndPassStonk}
+    <>
+      {isMobile && <MobileHeader pageName="IRR CALCULATOR" />}
+      <main className="irr-container">
+        <section className="irrform">
+          <div>Calculate Stonk IRR</div>
+          <LocalTypeahead
+            stonks={stonks}
+            setTickerAndPassStonk={setTickerAndPassStonk}
+          />
+          <div>
+            <div>Name: {chosenStonk.companyName}</div>
+            <div>Ticker: {chosenStonk.symbol}</div>
+            <div>EPS: {chosenStonk.ttmEPS}</div>
+            <div>latestPrice: {chosenStonk.latestPrice}</div>
+          </div>
+          <IRRWidget
+            stonk={chosenStonk}
+            setPriceChartData={setPriceChartData}
+            setPercentageChartData={setPercentageChartData}
+          />
+        </section>
+        <ValuationProbabilities data={priceChartData} chartClass="charta" />
+        <ValuationProbabilities
+          data={percentageChartData}
+          chartClass="chartb"
         />
-        <div>
-          <div>Name: {chosenStonk.companyName}</div>
-          <div>Ticker: {chosenStonk.symbol}</div>
-          <div>EPS: {chosenStonk.ttmEPS}</div>
-          <div>latestPrice: {chosenStonk.latestPrice}</div>
-        </div>
-        <IRRWidget
-          stonk={chosenStonk}
-          setPriceChartData={setPriceChartData}
-          setPercentageChartData={setPercentageChartData}
-        />
-      </section>
-      <ValuationProbabilities data={priceChartData} chartClass="charta" />
-      <ValuationProbabilities data={percentageChartData} chartClass="chartb" />
-    </main>
+      </main>
+    </>
   );
 }
 

--- a/src/pages/addstonk.css
+++ b/src/pages/addstonk.css
@@ -1,0 +1,39 @@
+@media (max-width: 768px) {
+  .add-stonks {
+    margin: 2rem 0 0;
+    display: grid;
+    grid-template-columns: 100%;
+    /* width: 50vw; */
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1200px) {
+  .add-stonks {
+    margin: 2rem 0 0 4.5rem;
+    display: grid;
+    grid-template-columns: 100%;
+    border: hsl(0, 0%, 80%) solid 1px;
+    border-radius: 10px;
+    /* width: 80%; */
+  }
+}
+
+@media (min-width: 1200px) {
+  .add-stonks {
+    margin: 5rem 0 0 4.5rem;
+    display: grid;
+    grid-template-columns: 45% 30%;
+    border: hsl(0, 0%, 80%) solid 1px;
+    border-radius: 10px;
+    width: 80%;
+  }
+}
+
+.add-stonk-form {
+  padding: 1rem;
+}
+
+.add-stonk-heading {
+  color: #282c34;
+  font-size: 23px;
+}

--- a/src/pages/dashboard.css
+++ b/src/pages/dashboard.css
@@ -106,7 +106,7 @@
   }
 
   .stonks-container {
-    margin-top: 2rem;
+    margin-top: 4rem;
     display: grid;
     grid-template-areas: "stonk";
     row-gap: 25px;


### PR DESCRIPTION
We previously added a bottom mobile nav for a more native app/PWA look, but it looked odd without a header.  This work implements that new header.

Also includes some css refactor/cleanup to move css classes closer to where they're used instead of just all jammed into a big App.css file.