### PR TITLE
Fix Black Text

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  color: #fff;
   background-color: #1a1b26;
 }
 

--- a/src/pages/addstonk.css
+++ b/src/pages/addstonk.css
@@ -34,6 +34,5 @@
 }
 
 .add-stonk-heading {
-  color: #282c34;
   font-size: 23px;
 }


### PR DESCRIPTION
In non-dark mode browsers the text is showing as black.  This is a quick fix for that.